### PR TITLE
Fix notation & hierarchy for "Studienbereich Biologie"

### DIFF
--- a/hochschulfaechersystematik.ttl
+++ b/hochschulfaechersystematik.ttl
@@ -1478,9 +1478,9 @@
 
 <n42> a skos:Concept ;
   skos:prefLabel "Studienbereich Biologie"@de ;
-  skos:narrower <n009>, <n42>, <n300>, <n282>;
+  skos:narrower <n009>, <n026>, <n300>, <n282>;
   skos:broader <n4> ;
-  skos:notation "080001" ;
+  skos:notation "42" ;
   skos:inScheme <scheme> .
 
 <n009> a skos:Concept ;


### PR DESCRIPTION
@mic-men hatte das per E-mail gemeldet:


Am 20.02.20 um 12:22 schrieb Michael Menzel:
> habe gerade gesehen, dass im SKOS der Fachgebiete bei Biologie was faul 
> ist, sowohl die vor dem Namen angezeigte Nr. als auch die 
> Hierarchieebenen betreffend, s. Screenshot.

![image](https://user-images.githubusercontent.com/160292/75013518-bf4afb80-5484-11ea-9887-0700b5a5b38a.png)

Dieser PR korrigiert die Notation und repariert einen Selbstverweis von https://w3id.org/kim/hochschulfaechersystematik/n42 in der Hierarchie.

@mic-men, schau dir bitte den Branch an unter https://skohub.io/dini-ag-kim/hochschulfaechersystematik/heads/fixBiologie/w3id.org/kim/hochschulfaechersystematik/scheme.html und merge in den Master, wenn alles stimmt.