### PR TITLE
Added missing broader entry for n090

### DIFF
--- a/hochschulfaechersystematik.ttl
+++ b/hochschulfaechersystematik.ttl
@@ -516,6 +516,7 @@
 
 <n090> a skos:Concept ;
   skos:prefLabel "Lernbereich Geisteswissenschaften"@de, "Area of study: Humanities"@en, "Галузь знань: гуманітарні науки"@uk ;
+  skos:broader <n01> ;
   skos:notation "090" ;
   skos:inScheme <scheme> .
 


### PR DESCRIPTION
Nur um konsistent zu sein - bisher wurde sonst sowohl `broader` als auch `narrower` gesetzt. Dies ist aber eigtl gar nicht nötig - siehe https://github.com/dini-ag-kim/hochschulfaechersystematik/issues/35#issuecomment-1923622346