### PR TITLE
Use machine-readable isReplacedBy statement

### DIFF
--- a/hochschulfaechersystematik.ttl
+++ b/hochschulfaechersystematik.ttl
@@ -1640,7 +1640,7 @@
   skos:broader <n37> ;
   skos:notation "237" ;
   skos:deprecated true ;
-  skos:note "Replaced by n312."@en ;
+  dct:isReplacedBy <n312> ;
   skos:inScheme <scheme> .
 
 <n118> a skos:Concept ;


### PR DESCRIPTION
...instead of skos:note. Reworking #14

This will enable applications to link deprecated concepts to their successors. E.g. SkoHub Vocabs uses this information, see https://github.com/skohub-io/skohub-vocabs/issues/287