### PR TITLE
29 shacl

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
           echo $validation_result
           lines=$(echo "$validation_result" | wc -l )
           # Correct validation has 4 lines of output
-          [[ ${lines} -eq 4 ]] || exit 1
+          [[ ${lines} -eq 4 ]] || echo "::warning file=app.js,line=1,col=5,endColumn=7::Missing semicolon"
         done
 
   validate-for-errors:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,15 +10,13 @@ jobs:
       uses: actions/checkout@v3
       
     - name: Check for Warnings
-      continue-on-error: true
       run: |
         curl -s https://raw.githubusercontent.com/skohub-io/shapes/main/scripts/checkForWarning.rq >> checkForWarning.rq
         find . -type f -name '*.ttl' | while read file; do
           # Adjust the file path to remove the './' part
           adjusted_file_path=$(echo "$file" | sed 's|^./||')  
           echo "Processing $adjusted_file_path with Docker..."
-          result="$(docker run --rm -v "$(pwd)/$adjusted_file_path:/rdf/test.ttl" skohub/jena:4.6.1 shacl validate --shapes https://raw.githubusercontent.com/skohub-io/shapes/main/skohub.shacl.ttl --data /rdf/test.ttl)"
-          echo $result > result.ttl
+          docker run --rm -v "$(pwd)/$adjusted_file_path:/rdf/test.ttl" skohub/jena:4.6.1 shacl validate --shapes https://raw.githubusercontent.com/skohub-io/shapes/main/skohub.shacl.ttl --data /rdf/test.ttl >> result.ttl
           validation_result="$(docker run --rm --mount type=bind,source=./checkForWarning.rq,target=/rdf/checkForViolation.rq --mount type=bind,source=./result.ttl,target=/rdf/result.ttl skohub/jena:4.6.1 arq --data /rdf/result.ttl --query /rdf/checkForViolation.rq)"
           echo $validation_result
           lines=$(echo "$validation_result" | wc -l )
@@ -39,8 +37,7 @@ jobs:
           # Adjust the file path to remove the './' part
           adjusted_file_path=$(echo "$file" | sed 's|^./||')  
           echo "Processing $adjusted_file_path with Docker..."
-          result="$(docker run --rm -v "$(pwd)/$adjusted_file_path:/rdf/test.ttl" skohub/jena:4.6.1 shacl validate --shapes https://raw.githubusercontent.com/skohub-io/shapes/main/skohub.shacl.ttl --data /rdf/test.ttl)"
-          echo $result > result.ttl
+          docker run --rm -v "$(pwd)/$adjusted_file_path:/rdf/test.ttl" skohub/jena:4.6.1 shacl validate --shapes https://raw.githubusercontent.com/skohub-io/shapes/main/skohub.shacl.ttl --data /rdf/test.ttl >> result.ttl
           validation_result="$(docker run --rm --mount type=bind,source=./checkForViolation.rq,target=/rdf/checkForViolation.rq --mount type=bind,source=./result.ttl,target=/rdf/result.ttl skohub/jena:4.6.1 arq --data /rdf/result.ttl --query /rdf/checkForViolation.rq)"
           echo $validation_result
           lines=$(echo "$validation_result" | wc -l )

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,20 @@
+name: Validate TTL Files
+
+on: [push] 
+
+jobs:
+  validate-ttl:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      
+    - name: Find and process .ttl files
+      run: |
+        find . -type f -name '*.ttl' | while read file; do
+          # Adjust the file path to remove the './' part
+          adjusted_file_path=$(echo "$file" | sed 's|^./||')  
+          echo "Processing $adjusted_file_path with Docker..."
+          docker run --rm -v "$file:/data/$adjusted_file_path" skohub/jena:4.6.1 "shacl validate --shapes https://raw.githubusercontent.com/skohub-io/shapes/main/skohub.shacl.ttl --data /data/$adjusted_file_path"
+        done
+

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,7 @@ jobs:
           echo $validation_result
           lines=$(echo "$validation_result" | wc -l )
           # Correct validation has 4 lines of output
-          [[ ${lines} -eq 4 ]] || echo "::warning file=app.js,line=1,col=5,endColumn=7::Missing semicolon"
+          [[ ${lines} -eq 4 ]] || exit 1
         done
 
   validate-for-errors:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,7 +3,7 @@ name: Validate TTL Files
 on: [push] 
 
 jobs:
-  validate-ttl:
+  validate-for-warnings:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -12,35 +12,39 @@ jobs:
     - name: Check for Warnings
       continue-on-error: true
       run: |
+        curl -s https://raw.githubusercontent.com/skohub-io/shapes/main/scripts/checkForWarning.rq >> checkForWarning.rq
         find . -type f -name '*.ttl' | while read file; do
           # Adjust the file path to remove the './' part
           adjusted_file_path=$(echo "$file" | sed 's|^./||')  
           echo "Processing $adjusted_file_path with Docker..."
-          docker run --rm -v "$(pwd)/$adjusted_file_path:/rdf/test.ttl" skohub/jena:4.6.1 riot --validate /rdf/test.ttl
           result="$(docker run --rm -v "$(pwd)/$adjusted_file_path:/rdf/test.ttl" skohub/jena:4.6.1 shacl validate --shapes https://raw.githubusercontent.com/skohub-io/shapes/main/skohub.shacl.ttl --data /rdf/test.ttl)"
           echo $result > result.ttl
-          curl -s https://raw.githubusercontent.com/skohub-io/shapes/main/scripts/checkForWarning.rq >> checkForWarning.rq
-          validationResult="$(docker run --rm --mount type=bind,source=./checkForWarning.rq,target=/rdf/checkForViolation.rq --mount type=bind,source=./result.ttl,target=/rdf/result.ttl skohub/jena:4.6.1 arq --data /rdf/result.ttl --query /rdf/checkForViolation.rq)"
-          echo $validationResult
-          lines=$(echo "$validationResult" | wc -l )
+          validation_result="$(docker run --rm --mount type=bind,source=./checkForWarning.rq,target=/rdf/checkForViolation.rq --mount type=bind,source=./result.ttl,target=/rdf/result.ttl skohub/jena:4.6.1 arq --data /rdf/result.ttl --query /rdf/checkForViolation.rq)"
+          echo $validation_result
+          lines=$(echo "$validation_result" | wc -l )
           # Correct validation has 4 lines of output
-          [[ ${lines} -eq 4 ]] || die "$validationResult"
+          [[ ${lines} -eq 4 ]] || exit 1
         done
 
+  validate-for-errors:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      
     - name: Check for Errors
       run: |
+        curl -s https://raw.githubusercontent.com/skohub-io/shapes/main/scripts/checkForViolation.rq >> checkForViolation.rq
         find . -type f -name '*.ttl' | while read file; do
           # Adjust the file path to remove the './' part
           adjusted_file_path=$(echo "$file" | sed 's|^./||')  
           echo "Processing $adjusted_file_path with Docker..."
-          docker run --rm -v "$(pwd)/$adjusted_file_path:/rdf/test.ttl" skohub/jena:4.6.1 riot --validate /rdf/test.ttl
           result="$(docker run --rm -v "$(pwd)/$adjusted_file_path:/rdf/test.ttl" skohub/jena:4.6.1 shacl validate --shapes https://raw.githubusercontent.com/skohub-io/shapes/main/skohub.shacl.ttl --data /rdf/test.ttl)"
           echo $result > result.ttl
-          curl -s https://raw.githubusercontent.com/skohub-io/shapes/main/scripts/checkForViolation.rq >> checkForViolation.rq
-          validationResult="$(docker run --rm --mount type=bind,source=./checkForViolation.rq,target=/rdf/checkForViolation.rq --mount type=bind,source=./result.ttl,target=/rdf/result.ttl skohub/jena:4.6.1 arq --data /rdf/result.ttl --query /rdf/checkForViolation.rq)"
-          echo $validationResult
-          lines=$(echo "$validationResult" | wc -l )
+          validation_result="$(docker run --rm --mount type=bind,source=./checkForViolation.rq,target=/rdf/checkForViolation.rq --mount type=bind,source=./result.ttl,target=/rdf/result.ttl skohub/jena:4.6.1 arq --data /rdf/result.ttl --query /rdf/checkForViolation.rq)"
+          echo $validation_result
+          lines=$(echo "$validation_result" | wc -l )
           # Correct validation has 4 lines of output
-          [[ ${lines} -eq 4 ]] || die "$validationResult"
+          [[ ${lines} -eq 4 ]] || exit 1
         done
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,7 @@ on: [push]
 
 jobs:
   validate-for-warnings:
+    name: Check for Warnings
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -25,6 +26,7 @@ jobs:
         done
 
   validate-for-errors:
+    name: Check for Errors
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,6 +15,11 @@ jobs:
           # Adjust the file path to remove the './' part
           adjusted_file_path=$(echo "$file" | sed 's|^./||')  
           echo "Processing $adjusted_file_path with Docker..."
-          docker run --rm -v "$file:/data/$adjusted_file_path" skohub/jena:4.6.1 "shacl validate --shapes https://raw.githubusercontent.com/skohub-io/shapes/main/skohub.shacl.ttl --data /data/$adjusted_file_path"
+          docker run --rm -v "$(pwd)/$adjusted_file_path:/rdf/test.ttl" skohub/jena:4.6.1 riot --validate /rdf/test.ttl
+          result="$(docker run --rm -v "$(pwd)/$adjusted_file_path:/rdf/test.ttl" skohub/jena:4.6.1 shacl validate --shapes https://raw.githubusercontent.com/skohub-io/shapes/main/skohub.shacl.ttl --data /rdf/test.ttl)"
+          echo $result > result.ttl
+          curl -s https://raw.githubusercontent.com/skohub-io/shapes/main/scripts/checkForWarning.rq >> checkForWarning.rq
+          validationResult="$(docker run --rm --mount type=bind,source=./checkForWarning.rq,target=/rdf/checkForViolation.rq --mount type=bind,source=./result.ttl,target=/rdf/result.ttl skohub/jena:4.6.1 arq --data /rdf/result.ttl --query /rdf/checkForViolation.rq)"
+          echo $validationResult
         done
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,7 +9,8 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
       
-    - name: Find and process .ttl files
+    - name: Check for Warnings
+      continue-on-error: true
       run: |
         find . -type f -name '*.ttl' | while read file; do
           # Adjust the file path to remove the './' part
@@ -21,5 +22,25 @@ jobs:
           curl -s https://raw.githubusercontent.com/skohub-io/shapes/main/scripts/checkForWarning.rq >> checkForWarning.rq
           validationResult="$(docker run --rm --mount type=bind,source=./checkForWarning.rq,target=/rdf/checkForViolation.rq --mount type=bind,source=./result.ttl,target=/rdf/result.ttl skohub/jena:4.6.1 arq --data /rdf/result.ttl --query /rdf/checkForViolation.rq)"
           echo $validationResult
+          lines=$(echo "$validationResult" | wc -l )
+          # Correct validation has 4 lines of output
+          [[ ${lines} -eq 4 ]] || die "$validationResult"
+        done
+
+    - name: Check for Errors
+      run: |
+        find . -type f -name '*.ttl' | while read file; do
+          # Adjust the file path to remove the './' part
+          adjusted_file_path=$(echo "$file" | sed 's|^./||')  
+          echo "Processing $adjusted_file_path with Docker..."
+          docker run --rm -v "$(pwd)/$adjusted_file_path:/rdf/test.ttl" skohub/jena:4.6.1 riot --validate /rdf/test.ttl
+          result="$(docker run --rm -v "$(pwd)/$adjusted_file_path:/rdf/test.ttl" skohub/jena:4.6.1 shacl validate --shapes https://raw.githubusercontent.com/skohub-io/shapes/main/skohub.shacl.ttl --data /rdf/test.ttl)"
+          echo $result > result.ttl
+          curl -s https://raw.githubusercontent.com/skohub-io/shapes/main/scripts/checkForViolation.rq >> checkForViolation.rq
+          validationResult="$(docker run --rm --mount type=bind,source=./checkForViolation.rq,target=/rdf/checkForViolation.rq --mount type=bind,source=./result.ttl,target=/rdf/result.ttl skohub/jena:4.6.1 arq --data /rdf/result.ttl --query /rdf/checkForViolation.rq)"
+          echo $validationResult
+          lines=$(echo "$validationResult" | wc -l )
+          # Correct validation has 4 lines of output
+          [[ ${lines} -eq 4 ]] || die "$validationResult"
         done
 


### PR DESCRIPTION
Ich habe eine GitHub Action hinzugefügt, die die Turtle Dateien in einem Repo auf Warnung und Fehler gegen die [SkoHub SHACL Shape](https://github.com/skohub-io/shapes/blob/main/skohub.shacl.ttl) validiert. 
Eine Validierung wird bei jedem Push in das Repo vorgenommen.

In diesem Fall, gibt es eine Warnung, weil es keinen Lizenzhinweis in den Daten gibt.
Einen Fehler gibt es nicht.

Wenn das Vorgehen so passt, dokumentiere ich in dem [SkoHub Shape Repo](https://github.com/skohub-io/shapes/tree/main), wie eine entsprechende Validierung in ein Vokabular Repo eingebaut werden kann.